### PR TITLE
:wrench: Add jgitver config for the main branch

### DIFF
--- a/.mvn/jgitver.config.xml
+++ b/.mvn/jgitver.config.xml
@@ -1,0 +1,5 @@
+<configuration xmlns="http://jgitver.github.io/maven/configuration/1.1.0"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://jgitver.github.io/maven/configuration/1.1.0 https://jgitver.github.io/maven/configuration/jgitver-configuration-v1_1_0.xsd">
+  <nonQualifierBranches>main</nonQualifierBranches>
+</configuration>


### PR DESCRIPTION
Set "main" as default branch for jgitver so that it does not appear in version numbers.