### PR TITLE
:art: Improve naming and documentation of environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Configuration is done using environment variables:
 * `AMQP_USER`: RabbitMQ user
 * `AMQP_PASS`: RabbitMQ password
 * `AMQP_VHOST`: RabbitMQ virtual host, defaults to '/'
-* `CANONIZER_TASK_QUEUE`: AMQP queue for receiving reduction tasks
-* `RETRIEVAL_TASK_QUEUE`: AMQP queue retrieval tasks
+* `CANONIZER_TASK_QUEUE`: AMQP queue (inbound) for receiving reduction tasks from the [API Gateway](https://github.com/penguineer/cleanURI-apigateway)
+* `EXTRACTOR_TASK_RK`: AMQP routing key (outbound) for tasks to the [Extractor](https://github.com/penguineer/cleanURI-extractor)
 
 ## Deployment
 

--- a/src/main/java/com/penguineering/cleanuri/canonizer/amqp/ReductionTaskHandler.java
+++ b/src/main/java/com/penguineering/cleanuri/canonizer/amqp/ReductionTaskHandler.java
@@ -16,8 +16,8 @@ import java.util.Optional;
 
 @RabbitListener
 public class ReductionTaskHandler {
-    @Property(name = "canonizer.retrieval-task-queue")
-    String taskQueue;
+    @Property(name = "canonizer.extractor-task-rk")
+    String extractorTaskRK;
 
     @Inject
     ExtractionTaskEmitter emitter;
@@ -49,7 +49,7 @@ public class ReductionTaskHandler {
 
         final ExtractionTask resultTask = taskBuilder.instance();
         emitter.send(
-                resultTask.getErrors().isEmpty() ? taskQueue : replyTo,
+                resultTask.getErrors().isEmpty() ? extractorTaskRK : replyTo,
                 correlationId, replyTo, resultTask);
 
         acknowledgement.ack();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,4 +26,4 @@ rabbitmq:
 
 canonizer:
   reduction-task-queue: ${CANONIZER_TASK_QUEUE}
-  retrieval-task-queue: ${RETRIEVAL_TASK_QUEUE}
+  extractor-task-rk: ${EXTRACTOR_TASK_RK}


### PR DESCRIPTION
The current naming scheme is not very clear on the AMQP endpoints (queues, routing keys) that are used and their respective purpose. This PR employs a (hopefully) clear naming scheme for easier configuration of the service.