### PR TITLE
:arrow_up: Update to Java 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # This dockerfile expects a compiled artifact in the target folder.
 # Call "mvn clean package" first!
 #
-FROM openjdk:17-jdk-slim
+FROM openjdk:21-jdk-slim
 
 RUN apt-get update && apt-get install -y \
     curl \

--- a/pom.xml
+++ b/pom.xml
@@ -21,11 +21,11 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <packaging>jar</packaging>
-    <jdk.version>17</jdk.version>
-    <release.version>17</release.version>
+    <jdk.version>21</jdk.version>
+    <release.version>21</release.version>
     <micronaut.version>3.5.1</micronaut.version>
     <micronaut.runtime>netty</micronaut.runtime>
     <exec.mainClass>com.penguineering.cleanuri.canonizer.Application</exec.mainClass>


### PR DESCRIPTION
This pull request includes updates to the Java version used in both the Dockerfile and the Maven build configuration. The most important changes are:

Java version update:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L5-R5): Updated the base image from `openjdk:17-jdk-slim` to `openjdk:21-jdk-slim` to use Java 21.
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L24-R28): Updated the Maven compiler source and target versions from 17 to 21, and changed the `jdk.version` and `release.version` properties to 21.