### PR TITLE
:arrow_up: Pin logback-classic to 1.5.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
+      <version>1.5.17</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This pull request includes an update to the `pom.xml` file to specify the version of the `logback-classic` dependency.

Dependency version update:

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R103): Added the version `1.5.17` for the `logback-classic` dependency to ensure consistency across environments.