### PR TITLE
:arrow_up: Bump cleanURI dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>com.github.penguineer</groupId>
       <artifactId>cleanURI-site-implementations</artifactId>
-      <version>0.2.0</version>
+      <version>0.3.0</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>com.github.penguineer</groupId>
       <artifactId>cleanURI-common</artifactId>
-      <version>0.3.0</version>
+      <version>0.4.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This pull request includes updates to the dependencies in the `pom.xml` file, specifically upgrading the versions of two dependencies.

Dependency updates:

* Updated `cleanURI-common` dependency version from `0.3.0` to `0.4.0` for compile scope.
* Updated `cleanURI-site-implementations` dependency version from `0.2.0` to `0.3.0` for runtime scope.