### PR TITLE
:arrow_up: Bump cleanURI-site-implementations to 0.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>com.github.penguineer</groupId>
       <artifactId>cleanURI-site-implementations</artifactId>
-      <version>0.3.0</version>
+      <version>0.3.1</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This pull request updates the version of the `cleanURI-site-implementations` dependency from `0.3.0` to `0.3.1` to include the Reichelt extraction fix.

* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L135-R135): Updated `cleanURI-site-implementations` dependency version from `0.3.0` to `0.3.1`.